### PR TITLE
NameTags: Add Use Unicode font setting (as a workaround) for names containing Unicode characters

### DIFF
--- a/Horion/DrawUtils.cpp
+++ b/Horion/DrawUtils.cpp
@@ -232,7 +232,7 @@ void DrawUtils::drawBox(vec3_t lower, vec3_t upper, float lineWidth)
 	}
 }
 
-void DrawUtils::drawNameTags(C_Entity* ent, float textSize,bool drawHealth)
+void DrawUtils::drawNameTags(C_Entity* ent, float textSize, bool drawHealth, bool useUnicodeFont)
 {
 	vec2_t textPos;
 	std::string text = ent->getNameTag()->getText();
@@ -242,7 +242,7 @@ void DrawUtils::drawNameTags(C_Entity* ent, float textSize,bool drawHealth)
 	if (refdef->OWorldToScreen(origin,ent->eyePos0, textPos, fov, screenSize)) {
 		textPos.y -= 10.f;
 		textPos.x -= textStr / 2.f;
-		drawText(textPos, &text,nullptr, textSize);
+		drawText(textPos, &text, nullptr, textSize, useUnicodeFont ? UNICOD : SMOOTH);
 	}
 }
 

--- a/Horion/DrawUtils.h
+++ b/Horion/DrawUtils.h
@@ -66,7 +66,7 @@ public:
 	static void rainbow(float* rcolors);
 	static void drawBox(vec3_t lower, vec3_t upper, float lineWidth);
 	static void drawEntityBox(C_Entity* ent, float lineWidth);
-	static void drawNameTags(C_Entity* ent, float textSize,bool drawHealth = false);
+	static void drawNameTags(C_Entity* ent, float textSize, bool drawHealth = false, bool useUnicodeFont = false);
 	static void wirebox(AABB aabb);
 
 	static vec2_t worldToScreen(vec3_t world);

--- a/Horion/Module/Modules/NameTags.cpp
+++ b/Horion/Module/Modules/NameTags.cpp
@@ -4,7 +4,8 @@
 
 NameTags::NameTags() : IModule(0x0, VISUAL)
 {
-	this->registerBoolSetting("Display Health", &this->DisplayHealth, this->DisplayHealth);
+	this->registerBoolSetting("Display Health", &this->displayHealth, this->displayHealth);
+	this->registerBoolSetting("Use Unicode font", &this->useUnicodeFont, this->useUnicodeFont);
 }
 
 
@@ -26,7 +27,7 @@ void drawNameTags(C_Entity* ent, bool isRegularEntitie) {
 		if (ent->timeSinceDeath > 0)
 			return;
 		if (Target::isValidTarget(ent) && NameTagsMod != nullptr)
-			DrawUtils::drawNameTags(ent, 0.95f);
+			DrawUtils::drawNameTags(ent, 0.95f, NameTagsMod->displayHealth, NameTagsMod->useUnicodeFont);
 	}
 }
 

--- a/Horion/Module/Modules/NameTags.h
+++ b/Horion/Module/Modules/NameTags.h
@@ -6,10 +6,9 @@
 
 class NameTags : public IModule
 {
-private:
-	bool DisplayHealth = true;
 public:
-	inline bool shouldDisplayHealth() { return DisplayHealth; };
+	bool displayHealth = true;
+	bool useUnicodeFont = false;
 	NameTags();
 	~NameTags();
 


### PR DESCRIPTION
Noto Sans does not work well with Unicode characters (Hangul, Hiragana/Katakana, etc.).