### PR TITLE
Fix teleport issue and centre the player to the block

### DIFF
--- a/Horion/Command/Commands/TeleportCommand.cpp
+++ b/Horion/Command/Commands/TeleportCommand.cpp
@@ -22,7 +22,6 @@ bool TeleportCommand::execute(std::vector<std::string>* args)
 	vec3_t pos;
 	pos.x = assertFloat(args->at(1))+(float)0.5;
 	pos.y = assertFloat(args->at(2))+(float)g_Data.getLocalPlayer()->height;
-	clientMessageF("%s%f", GREEN, (float)g_Data.getLocalPlayer()->height);
 	pos.z = assertFloat(args->at(3))+(float)0.5;
 
 	g_Data.getLocalPlayer()->setPos(pos);

--- a/Horion/Command/Commands/TeleportCommand.cpp
+++ b/Horion/Command/Commands/TeleportCommand.cpp
@@ -20,9 +20,9 @@ bool TeleportCommand::execute(std::vector<std::string>* args)
 	assertTrue(args->size() >= 4);
 
 	vec3_t pos;
-	pos.x = assertFloat(args->at(1));
-	pos.y = assertFloat(args->at(2));
-	pos.z = assertFloat(args->at(3));
+	pos.x = assertFloat(args->at(1))+0.5;
+	pos.y = assertFloat(args->at(2))+1.5;
+	pos.z = assertFloat(args->at(3))+0.5;
 
 	g_Data.getLocalPlayer()->setPos(pos);
 	clientMessageF("%sTeleported!", GREEN);

--- a/Horion/Command/Commands/TeleportCommand.cpp
+++ b/Horion/Command/Commands/TeleportCommand.cpp
@@ -20,9 +20,9 @@ bool TeleportCommand::execute(std::vector<std::string>* args)
 	assertTrue(args->size() >= 4);
 
 	vec3_t pos;
-	pos.x = assertFloat(args->at(1))+(float)0.5;
+	pos.x = assertFloat(args->at(1))+0.5f;
 	pos.y = assertFloat(args->at(2))+(float)g_Data.getLocalPlayer()->height;
-	pos.z = assertFloat(args->at(3))+(float)0.5;
+	pos.z = assertFloat(args->at(3))+0.5f;
 
 	g_Data.getLocalPlayer()->setPos(pos);
 	clientMessageF("%sTeleported!", GREEN);

--- a/Horion/Command/Commands/TeleportCommand.cpp
+++ b/Horion/Command/Commands/TeleportCommand.cpp
@@ -20,9 +20,10 @@ bool TeleportCommand::execute(std::vector<std::string>* args)
 	assertTrue(args->size() >= 4);
 
 	vec3_t pos;
-	pos.x = assertFloat(args->at(1))+0.5;
-	pos.y = assertFloat(args->at(2))+1.5;
-	pos.z = assertFloat(args->at(3))+0.5;
+	pos.x = assertFloat(args->at(1))+(float)0.5;
+	pos.y = assertFloat(args->at(2))+(float)g_Data.getLocalPlayer()->height;
+	clientMessageF("%s%f", GREEN, (float)g_Data.getLocalPlayer()->height);
+	pos.z = assertFloat(args->at(3))+(float)0.5;
 
 	g_Data.getLocalPlayer()->setPos(pos);
 	clientMessageF("%sTeleported!", GREEN);


### PR DESCRIPTION
When using the `tp` command, the player will be ~1.5 blocks lower than they chose, causing them to start suffocating (as they fall to the bottom of the second block). This PR fixes that issue and also places the player in the centre of the block they chose to teleport to, just like the official Minecraft command does.