### PR TITLE
DrawUtils: Temporarily disable Use Unicode font setting for name tags

### DIFF
--- a/Horion/DrawUtils.cpp
+++ b/Horion/DrawUtils.cpp
@@ -275,7 +275,7 @@ void DrawUtils::drawNameTags(C_Entity* ent, float textSize, bool drawHealth, boo
 	if (refdef->OWorldToScreen(origin,ent->eyePos0, textPos, fov, screenSize)) {
 		textPos.y -= 10.f;
 		textPos.x -= textStr / 2.f;
-		drawText(textPos, &text, nullptr, textSize, useUnicodeFont ? Fonts::UNICOD : Fonts::SMOOTH);
+		drawText(textPos, &text, nullptr, textSize/*, useUnicodeFont ? Fonts::UNICOD : Fonts::SMOOTH*/);
 	}
 }
 


### PR DESCRIPTION
This setting is no longer needed as our primary font is Mojangles now. Also, enabling it crashes the game (for some reason).