### PR TITLE
Improve .give, .enchant and .dupe

### DIFF
--- a/Horion/Command/Commands/DupeCommand.cpp
+++ b/Horion/Command/Commands/DupeCommand.cpp
@@ -1,6 +1,6 @@
 #include "DupeCommand.h"
 
-DupeCommand::DupeCommand() : IMCCommand("dupe", "Duplicates the item in hand", "<count>")
+DupeCommand::DupeCommand() : IMCCommand("dupe", "Duplicates the item in hand", "<count> <mode: give / offhand : 1/0>")
 {
 }
 
@@ -12,14 +12,38 @@ bool DupeCommand::execute(std::vector<std::string>* args)
 {
 	C_PlayerInventoryProxy* supplies = g_Data.getLocalPlayer()->getSupplies();
 	C_Inventory* inv = supplies->inventory;
+	auto transactionManager = g_Data.getLocalPlayer()->getTransactionManager();
 
 	int selectedSlot = supplies->selectedHotbarSlot;
 	C_ItemStack* item = inv->getItemStack(selectedSlot);
 
+	int count = item->count;
+	bool isGive = true;
+
 	if (args->size() > 1)
 		item->count = assertInt(args->at(1));
+	if (args->size() > 2)
+		isGive = static_cast<bool>(assertInt(args->at(2)));
 
-	g_Data.getLocalPlayer()->setOffhandSlot(item); // Items with NBT tags really don't work well with normal item giving method
+	if (isGive) {
+		int slot = inv->getFirstEmptySlot();
+
+		C_InventoryAction* firstAction = new C_InventoryAction(0, item, nullptr, 507, 99999);
+		C_InventoryAction* secondAction = new C_InventoryAction(slot, nullptr, item);
+		if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0) {
+			firstAction = new C_InventoryAction(slot, nullptr, item, 32512);
+			secondAction = new C_InventoryAction(0, item, nullptr, 156, 100);
+		}
+
+		transactionManager->addInventoryAction(*firstAction);
+		transactionManager->addInventoryAction(*secondAction);
+
+		inv->addItemToFirstEmptySlot(item);
+	} else {
+		g_Data.getLocalPlayer()->setOffhandSlot(item);
+	}
+
+	item->count = count;
 
 	clientMessageF("%sSuccessfully duplicated the item!", GREEN);
 	return true;

--- a/Horion/Command/Commands/DupeCommand.cpp
+++ b/Horion/Command/Commands/DupeCommand.cpp
@@ -25,7 +25,8 @@ bool DupeCommand::execute(std::vector<std::string>* args)
 	if (args->size() > 2)
 		isGive = static_cast<bool>(assertInt(args->at(2)));
 
-	if (isGive) {
+	if (isGive)
+	{
 		int slot = inv->getFirstEmptySlot();
 
 		C_InventoryAction* firstAction = new C_InventoryAction(0, item, nullptr, 507, 99999);
@@ -39,7 +40,9 @@ bool DupeCommand::execute(std::vector<std::string>* args)
 		transactionManager->addInventoryAction(*secondAction);
 
 		inv->addItemToFirstEmptySlot(item);
-	} else {
+	}
+	else
+	{
 		g_Data.getLocalPlayer()->setOffhandSlot(item);
 	}
 

--- a/Horion/Command/Commands/DupeCommand.cpp
+++ b/Horion/Command/Commands/DupeCommand.cpp
@@ -31,7 +31,8 @@ bool DupeCommand::execute(std::vector<std::string>* args)
 
 		C_InventoryAction* firstAction = new C_InventoryAction(0, item, nullptr, 507, 99999);
 		C_InventoryAction* secondAction = new C_InventoryAction(slot, nullptr, item);
-		if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0) {
+		if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0)
+		{
 			firstAction = new C_InventoryAction(slot, nullptr, item, 32512);
 			secondAction = new C_InventoryAction(0, item, nullptr, 156, 100);
 		}

--- a/Horion/Command/Commands/DupeCommand.cpp
+++ b/Horion/Command/Commands/DupeCommand.cpp
@@ -43,7 +43,8 @@ bool DupeCommand::execute(std::vector<std::string>* args)
 		g_Data.getLocalPlayer()->setOffhandSlot(item);
 	}
 
-	item->count = count;
+	if (args->size() > 1)
+		item->count = count;
 
 	clientMessageF("%sSuccessfully duplicated the item!", GREEN);
 	return true;

--- a/Horion/Command/Commands/EnchantCommand.cpp
+++ b/Horion/Command/Commands/EnchantCommand.cpp
@@ -90,6 +90,8 @@ bool EnchantCommand::execute(std::vector<std::string>* args)
 		{
 			firstAction = new C_InventoryAction(supplies->selectedHotbarSlot, item, nullptr);
 			secondAction = new C_InventoryAction(0, nullptr, item, 507, 99999);
+			if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0)
+				secondAction = new C_InventoryAction(0, nullptr, item, 32766, 100);
 			manager->addInventoryAction(*firstAction);
 			manager->addInventoryAction(*secondAction);
 		}
@@ -161,6 +163,8 @@ bool EnchantCommand::execute(std::vector<std::string>* args)
 	if (isAuto)
 	{
 		firstAction = new C_InventoryAction(0, item, nullptr, 507, 99999);
+		if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0)
+			firstAction = new C_InventoryAction(0, item, nullptr, 32766, 100);
 		secondAction = new C_InventoryAction(supplies->selectedHotbarSlot, nullptr, item);
 		manager->addInventoryAction(*firstAction);
 		manager->addInventoryAction(*secondAction);

--- a/Horion/Command/Commands/GiveCommand.cpp
+++ b/Horion/Command/Commands/GiveCommand.cpp
@@ -111,8 +111,12 @@ bool GiveCommand::execute(std::vector<std::string>* args)
 
 	int slot = inv->getFirstEmptySlot();
 
-	C_InventoryAction* firstAction =  new C_InventoryAction(0, yot, nullptr, 507, 99999);
-	C_InventoryAction* secondAction =  new C_InventoryAction(slot, nullptr, yot);
+	C_InventoryAction* firstAction = new C_InventoryAction(0, yot, nullptr, 507, 99999);
+	C_InventoryAction* secondAction = new C_InventoryAction(slot, nullptr, yot);
+	if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0) {
+		firstAction = new C_InventoryAction(slot, nullptr, yot, 32512);
+		secondAction = new C_InventoryAction(0, yot, nullptr, 156, 100);
+	}
 
 	transactionManager->addInventoryAction(*firstAction);
 	transactionManager->addInventoryAction(*secondAction);

--- a/Horion/Command/Commands/GiveCommand.cpp
+++ b/Horion/Command/Commands/GiveCommand.cpp
@@ -113,7 +113,8 @@ bool GiveCommand::execute(std::vector<std::string>* args)
 
 	C_InventoryAction* firstAction = new C_InventoryAction(0, yot, nullptr, 507, 99999);
 	C_InventoryAction* secondAction = new C_InventoryAction(slot, nullptr, yot);
-	if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0) {
+	if (strcmp(g_Data.getRakNetInstance()->serverIp.getText(), "mco.mineplex.com") == 0)
+	{
 		firstAction = new C_InventoryAction(slot, nullptr, yot, 32512);
 		secondAction = new C_InventoryAction(0, yot, nullptr, 156, 100);
 	}


### PR DESCRIPTION
- .give and .enchant once again work correctly on Mineplex
- .dupe is now fully automated just like .give and .enchant (the previous method is still available)
- .dupe no longer changes the count of the item in your hand when you run the command with the count parameter given