### PR TITLE
Player place + break functions

### DIFF
--- a/Horion/Scripting/Functions/LocalPlayerFunctions.cpp
+++ b/Horion/Scripting/Functions/LocalPlayerFunctions.cpp
@@ -190,3 +190,79 @@ JsValueRef CALLBACK LocalPlayerFunctions::getInventory(JsValueRef callee, bool i
 
 	return inventoryArr;
 }
+
+JsValueRef CALLBACK LocalPlayerFunctions::breakBlock(JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, void* callbackState) {
+	auto ent = EntityFunctions::getEntityFromValue(arguments[0]);
+	if (ent == nullptr) {
+		ENTITY_INVALID;
+	}
+
+	const auto plr = reinterpret_cast<C_LocalPlayer*>(ent);
+
+	auto vecOpt = Vector3Functions::getVec3FromArguments(&arguments[1], argumentCount - 1);
+	if (!vecOpt.has_value()) {
+		THROW(L"Invalid vector!");
+	}
+
+	vec3_ti pos = vecOpt.value();
+
+	g_Data.getCGameMode()->destroyBlock(&pos, 1);
+	return chakra.trueValue();
+}
+
+JsValueRef CALLBACK LocalPlayerFunctions::placeBlock(JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, void* callbackState) {
+	auto ent = EntityFunctions::getEntityFromValue(arguments[0]);
+	if (ent == nullptr) {
+		ENTITY_INVALID;
+	}
+
+	const auto plr = reinterpret_cast<C_LocalPlayer*>(ent);
+
+	auto vecOpt = Vector3Functions::getVec3FromArguments(&arguments[1], argumentCount - 1);
+	if (!vecOpt.has_value()) {
+		THROW(L"Invalid vector!");
+	}
+
+	vec3_ti pos = vecOpt.value();
+
+	g_Data.getCGameMode()->buildBlock(&pos, 1);
+	return chakra.trueValue();
+}
+
+JsValueRef CALLBACK LocalPlayerFunctions::breakBlockRelativeToPlr(JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, void* callbackState) {
+	auto ent = EntityFunctions::getEntityFromValue(arguments[0]);
+	if (ent == nullptr) {
+		ENTITY_INVALID;
+	}
+
+	const auto plr = reinterpret_cast<C_LocalPlayer*>(ent);
+
+	auto vecOpt = Vector3Functions::getVec3FromArguments(&arguments[1], argumentCount - 1);
+	if (!vecOpt.has_value()) {
+		THROW(L"Invalid vector!");
+	}
+
+	vec3_ti pos = vecOpt.value().add(*plr->getPos());
+
+	g_Data.getCGameMode()->destroyBlock(&pos, 1);
+	return chakra.trueValue();
+}
+
+JsValueRef CALLBACK LocalPlayerFunctions::placeBlockRelativeToPlr(JsValueRef callee, bool isConstructCall, JsValueRef* arguments, unsigned short argumentCount, void* callbackState) {
+	auto ent = EntityFunctions::getEntityFromValue(arguments[0]);
+	if (ent == nullptr) {
+		ENTITY_INVALID;
+	}
+
+	const auto plr = reinterpret_cast<C_LocalPlayer*>(ent);
+
+	auto vecOpt = Vector3Functions::getVec3FromArguments(&arguments[1], argumentCount - 1);
+	if (!vecOpt.has_value()) {
+		THROW(L"Invalid vector!");
+	}
+
+	vec3_ti pos = vecOpt.value().add(*plr->getPos());
+
+	g_Data.getCGameMode()->buildBlock(&pos, 1);
+	return chakra.trueValue();
+}

--- a/Horion/Scripting/Functions/LocalPlayerFunctions.h
+++ b/Horion/Scripting/Functions/LocalPlayerFunctions.h
@@ -14,4 +14,8 @@ public:
 	DECL_FUN(setIsOnGround);
 	DECL_FUN(getInventory);
 	DECL_FUN(getInventorySlot);
+	DECL_FUN(breakBlock);
+	DECL_FUN(placeBlock);
+	DECL_FUN(breakBlockRelativeToPlr);
+	DECL_FUN(placeBlockRelativeToPlr);
 };

--- a/Horion/Scripting/ScriptManager.cpp
+++ b/Horion/Scripting/ScriptManager.cpp
@@ -108,6 +108,11 @@ void ScriptManager::prepareLocalPlayerPrototype(JsValueRef proto, ContextObjects
 	chakra.defineFunction(proto, L"setIsOnGround", LocalPlayerFunctions::setIsOnGround, objs);
 	chakra.defineFunction(proto, L"getInventory", LocalPlayerFunctions::getInventory, objs);
 	chakra.defineFunction(proto, L"getInventorySlot", LocalPlayerFunctions::getInventorySlot, objs);
+
+	chakra.defineFunction(proto, L"placeBlock", LocalPlayerFunctions::placeBlock, objs);
+	chakra.defineFunction(proto, L"placeBlockRelative", LocalPlayerFunctions::placeBlockRelativeToPlr, objs);
+	chakra.defineFunction(proto, L"breakBlock", LocalPlayerFunctions::breakBlock, objs);
+	chakra.defineFunction(proto, L"breakBlockRelative", LocalPlayerFunctions::breakBlockRelativeToPlr, objs);
 }
 
 void ScriptManager::prepareGameFunctions(JsValueRef global, ContextObjects* objs) {


### PR DESCRIPTION
Adds functions for placing and breaking blocks to LocalPlayerFunctions

Api stuffs:

LocalPlayer#breakBlock(pos: Vec3): boolean
LocalPlayer#breakBlockRelative(pos: Vec3): boolean
LocalPlayer#placeBlock(pos: Vec3): boolean
LocalPlayer#placeBlockRelative(pos: Vec3): boolean

fuck me if this conflicts with the other pull i made